### PR TITLE
refactor(docker): Standardize container names and ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ This project is an AI-powered tool to generate videos from PowerPoint presentati
 
 The application is built with a microservices architecture, orchestrated by Docker Compose for easy local development.
 
-- **`api`**: A FastAPI application that serves the frontend and the backend REST API.
-- **`worker_cpu`**: A Celery worker for CPU-intensive tasks like presentation decomposition and video assembly with MoviePy.
-- **`worker_gpu`**: A Celery worker for GPU-intensive tasks, specifically voice synthesis with OpenVoice V2.
-- **`libreoffice`**: A dedicated service running a headless LibreOffice instance (wrapped in a Flask API) to convert `.pptx` files to images.
-- **`postgres`**: A PostgreSQL database for storing user, voice clone, and job metadata.
-- **`redis`**: A Redis instance that acts as the message broker for Celery.
-- **`minio`**: An S3-compatible object storage server for storing all files (presentations, voice samples, images, audio clips, and final videos).
+- **`api`**: A FastAPI application that serves the frontend and the backend REST API. The container is named `ppt-api`.
+- **`worker_cpu`**: A Celery worker for CPU-intensive tasks like presentation decomposition and video assembly with MoviePy. The container is named `ppt-worker-cpu`.
+- **`worker_gpu`**: A Celery worker for GPU-intensive tasks, specifically voice synthesis with OpenVoice V2. The container is named `ppt-worker-gpu`.
+- **`libreoffice`**: A dedicated service running a headless LibreOffice instance (wrapped in a Flask API) to convert `.pptx` files to images. The container is named `ppt-libreoffice`.
+- **`postgres`**: A PostgreSQL database for storing user, voice clone, and job metadata. The container is named `ppt-postgres`.
+- **`redis`**: A Redis instance that acts as the message broker for Celery. The container is named `ppt-redis`.
+- **`minio`**: An S3-compatible object storage server for storing all files (presentations, voice samples, images, audio clips, and final videos). The container is named `ppt-minio`.
 
 ## How to Run Locally
 
@@ -55,6 +55,8 @@ The application is built with a microservices architecture, orchestrated by Dock
     This command will build the Docker images for all the custom services and start all the containers. The `--build` flag is only necessary the first time or when you make changes to the Dockerfiles or application dependencies.
 
 5.  **Access the application**:
-    -   **Web Interface**: Open your browser and navigate to [http://localhost:8000](http://localhost:8000).
-    -   **API Docs**: The FastAPI documentation is available at [http://localhost:8000/docs](http://localhost:8000/docs).
-    -   **MinIO Console**: You can access the MinIO dashboard at [http://localhost:9001](http://localhost:9001) using the credentials from your `.env` file.
+    -   **Web Interface**: Open your browser and navigate to [http://localhost:18000](http://localhost:18000).
+    -   **API Docs**: The FastAPI documentation is available at [http://localhost:18000/docs](http://localhost:18000/docs).
+    -   **MinIO Console**: You can access the MinIO dashboard at [http://localhost:19001](http://localhost:19001) using the credentials from your `.env` file.
+    -   **Database**: The PostgreSQL database is exposed on `localhost:15432`.
+    -   **Redis**: The Redis server is exposed on `localhost:16379`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,33 +3,33 @@ version: '3.8'
 services:
   postgres:
     image: postgres:13
-    container_name: postgres
+    container_name: ppt-postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-user}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
       POSTGRES_DB: ${POSTGRES_DB:-presentation_gen_db}
     ports:
-      - "5432:5432"
+      - "15432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     restart: unless-stopped
 
   redis:
     image: redis:6.2-alpine
-    container_name: redis
+    container_name: ppt-redis
     ports:
-      - "6379:6379"
+      - "16379:6379"
     restart: unless-stopped
 
   minio:
     image: minio/minio:latest
-    container_name: minio
+    container_name: ppt-minio
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "19000:9000"
+      - "19001:9001"
     volumes:
       - minio_data:/data
     command: server /data --console-address ":9001"
@@ -37,7 +37,7 @@ services:
 
   create-minio-buckets:
     image: minio/mc
-    container_name: create-minio-buckets
+    container_name: ppt-create-minio-buckets
     depends_on:
       - minio
     entrypoint: >
@@ -62,7 +62,7 @@ services:
       - redis
       - minio
     ports:
-      - "8000:8000"
+      - "18000:8000"
     volumes:
       - ./app:/app
     environment:


### PR DESCRIPTION
This commit refactors the Docker configuration to standardize container names and port mappings for better clarity and to avoid conflicts with default ports.

- All container names are now prefixed with `ppt-`.
- Exposed ports have been moved to a higher range (1xxxx):
  - Postgres: 15432
  - Redis: 16379
  - MinIO: 19000 (service), 19001 (console)
  - API: 18000
- The `README.md` has been updated to reflect these changes.