### PR TITLE
fix(docker): Fix git build error and refactor config

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@ The application is built with a microservices architecture, orchestrated by Dock
     -   **MinIO Console**: You can access the MinIO dashboard at [http://localhost:19001](http://localhost:19001) using the credentials from your `.env` file.
     -   **Database**: The PostgreSQL database is exposed on `localhost:15432`.
     -   **Redis**: The Redis server is exposed on `localhost:16379`.
+    -   **LibreOffice**: The LibreOffice service is exposed on `localhost:18100`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       context: .
       dockerfile: docker/api/Dockerfile
     image: ppt-api
-    container_name: api
+    container_name: ppt-api
     depends_on:
       - postgres
       - redis
@@ -79,7 +79,7 @@ services:
       context: .
       dockerfile: docker/worker_cpu/Dockerfile
     image: ppt-worker-cpu
-    container_name: worker_cpu
+    container_name: ppt-worker_cpu
     depends_on:
       - redis
       - minio
@@ -100,7 +100,7 @@ services:
       context: .
       dockerfile: docker/worker_gpu/Dockerfile
     image: ppt-worker-gpu
-    container_name: worker_gpu
+    container_name: ppt-worker_gpu
     depends_on:
       - redis
       - minio
@@ -126,9 +126,9 @@ services:
       context: .
       dockerfile: docker/libreoffice/Dockerfile
     image: ppt-libreoffice
-    container_name: libreoffice
+    container_name: ppt-libreoffice
     ports:
-      - "8100:8100"
+      - "18100:8100"
     environment:
       - MINIO_URL=minio:9000
       - MINIO_ACCESS_KEY=${MINIO_ROOT_USER:-minioadmin}

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the requirements file into the container


### PR DESCRIPTION
This commit addresses two issues:

1.  Fixes a Docker build failure for the `api` service caused by the `git` command not being found. The `git` client is now installed in the `api` Dockerfile to allow cloning of git-based Python dependencies.

2.  Refactors the Docker configuration to standardize container names and port mappings for better clarity and to avoid conflicts.
    - All container names are now prefixed with `ppt-`.
    - Exposed ports have been moved to a higher range (1xxxx).
    - The `README.md` has been updated to reflect these changes.