### PR TITLE
fix(docker): Install git in worker_cpu Dockerfile

### DIFF
--- a/docker/worker_cpu/Dockerfile
+++ b/docker/worker_cpu/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .


### PR DESCRIPTION
The `worker_cpu` service was failing to build because the `git` command was not available to install a dependency from a git repository (`MeloTTS`).

This commit adds `git` to the list of installed packages in the `docker/worker_cpu/Dockerfile`, mirroring the fix previously applied to the `api` service.