### PR TITLE
Fix Docker build and runtime errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - minio
     entrypoint: >
       /bin/sh -c "
-      /usr/bin/mc config host add myminio http://minio:9000 ${MINIO_ROOT_USER:-minioadmin} ${MINIO_ROOT_PASSWORD:-minioadmin};
+      /usr/bin/mc alias set myminio http://minio:9000 ${MINIO_ROOT_USER:-minioadmin} ${MINIO_ROOT_PASSWORD:-minioadmin};
       /usr/bin/mc mb myminio/ingest || true;
       /usr/bin/mc mb myminio/output || true;
       /usr/bin/mc mb myminio/voice-clones || true;

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.9-slim
 
 # Set the working directory in the container
-WORKDIR /app
+WORKDIR /
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -20,4 +20,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY ./app /app
 
 # Command to run the application
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/docker/worker_cpu/Dockerfile
+++ b/docker/worker_cpu/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9-slim
 
-WORKDIR /app
+WORKDIR /
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -16,4 +16,4 @@ COPY ./app /app
 
 # Command to run the Celery worker
 # The queue 'cpu_tasks' will be for CPU-intensive tasks like video processing
-CMD ["celery", "-A", "workers.celery_app:app", "worker", "--loglevel=info", "-Q", "cpu_tasks"]
+CMD ["celery", "-A", "app.workers.celery_app:app", "worker", "--loglevel=info", "-Q", "cpu_tasks"]

--- a/docker/worker_gpu/Dockerfile
+++ b/docker/worker_gpu/Dockerfile
@@ -1,7 +1,7 @@
 # Use a base image with CUDA and PyTorch pre-installed
 FROM pytorch/pytorch:2.1.0-cuda12.1-cudnn8-runtime
 
-WORKDIR /app
+WORKDIR /
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -31,4 +31,4 @@ RUN curl -L -o checkpoints_v2.zip "https://myshell-public-repo-host.s3.amazonaws
 COPY ./app /app
 
 # Command to run the Celery worker for GPU tasks
-CMD ["celery", "-A", "workers.celery_app:app", "worker", "--loglevel=info", "-Q", "gpu_tasks", "-c", "1"]
+CMD ["celery", "-A", "app.workers.celery_app:app", "worker", "--loglevel=info", "-Q", "gpu_tasks", "-c", "1"]


### PR DESCRIPTION
This commit fixes several errors that occurred when running the application with docker-compose.

- The `api`, `worker_cpu`, and `worker_gpu` services were failing with a `ModuleNotFoundError: No module named 'app'`. This was because the working directory in the Docker containers was set to `/app`, but the application was being imported as a top-level package. The fix was to change the `WORKDIR` to `/` and update the `CMD` to use the full module path (e.g., `app.main:app`).

- The `create-minio-buckets` service was failing with an error `mc: <ERROR> 'config' is not a recognized command`. This was because the `mc config host add` command is deprecated. The fix was to use `mc alias set` instead, as suggested in the AGENTS.md file.