### PR TITLE
Fix Docker build and runtime errors

### DIFF
--- a/app/workers/tasks_cpu.py
+++ b/app/workers/tasks_cpu.py
@@ -1,6 +1,6 @@
 from app.workers.celery_app import app as celery_app
 from app.db.session import SessionLocal
-from app. import crud
+from app import crud
 from app.services.minio_service import minio_service
 from pptx import Presentation
 import requests

--- a/app/workers/tasks_gpu.py
+++ b/app/workers/tasks_gpu.py
@@ -1,6 +1,6 @@
 from app.workers.celery_app import app as celery_app
 from app.db.session import SessionLocal
-from app. import crud
+from app import crud
 from app.services.minio_service import minio_service
 import torch
 from openvoice import se_extractor


### PR DESCRIPTION
This commit fixes several errors that occurred when running the application with docker-compose.

- The `api`, `worker_cpu`, and `worker_gpu` services were failing with a `ModuleNotFoundError: No module named 'app'`. This was because the working directory in the Docker containers was set to `/app`, but the application was being imported as a top-level package. The fix was to change the `WORKDIR` to `/` and update the `CMD` to use the full module path (e.g., `app.main:app`).

- The `create-minio-buckets` service was failing with an error `mc: <ERROR> 'config' is not a recognized command`. This was because the `mc config host add` command is deprecated. The fix was to use `mc alias set` instead, as suggested in the AGENTS.md file.

- The `worker_cpu` and `worker_gpu` services were failing with a `ValidationError` because the `DATABASE_URL` environment variable was missing. This commit adds the `DATABASE_URL` to the worker services in `docker-compose.yml`.

- The `worker_cpu` and `worker_gpu` services were failing with a `SyntaxError` in the import statement for the `crud` module. This commit corrects the invalid syntax `from app. import crud` to `from app import crud` in `app/workers/tasks_cpu.py` and `app/workers/tasks_gpu.py`.