### PR TITLE
feat: Add configurable volume mounts for caching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,12 @@ PPT_SLIDES_VOLUME=./data/slides
 # Timeout settings for GPU audio synthesis tasks (in seconds)
 TTS_SOFT_TIME_LIMIT=300    # Soft timeout - triggers fallback (5 minutes)
 TTS_HARD_TIME_LIMIT=360    # Hard timeout - kills task (6 minutes)
+
+# Worker GPU Caches
+WORKER_GPU_NLTK_DATA=./data/nltk_data
+WORKER_GPU_HF_CACHE=./data/huggingface_cache
+WORKER_GPU_OPENVOKE_REPO=./data/OpenVoice
+WORKER_GPU_OPENVOKE_CHECKPOINTS=./data/checkpoints_v2
+
+# LibreOffice Temporary Files
+LIBREOFFICE_TMP_VOLUME=./data/libreoffice_tmp

--- a/.env.sample
+++ b/.env.sample
@@ -11,3 +11,12 @@ MINIO_ROOT_PASSWORD=minioadmin
 # Set these to map Docker volumes to host directories
 PPT_OUTPUT_VOLUME=/MWC/data/ppt/output
 PPT_SLIDES_VOLUME=/MWC/data/ppt/slides
+
+# Worker GPU Caches
+WORKER_GPU_NLTK_DATA=/MWC/data/nltk_data
+WORKER_GPU_HF_CACHE=/MWC/data/huggingface_cache
+WORKER_GPU_OPENVOKE_REPO=/MWC/data/OpenVoice
+WORKER_GPU_OPENVOKE_CHECKPOINTS=/MWC/data/checkpoints_v2
+
+# LibreOffice Temporary Files
+LIBREOFFICE_TMP_VOLUME=/MWC/data/libreoffice_tmp

--- a/Agents.md
+++ b/Agents.md
@@ -142,6 +142,13 @@ TTS_HARD_TIME_LIMIT=360    # Hard timeout - kills hung tasks (6 minutes)
 GPU_RUNTIME=nvidia         # or 'runc' for CPU-only mode
 GPU_COUNT=1               # Number of GPUs to use
 NVIDIA_VISIBLE_DEVICES=all # GPU device visibility
+
+# Volume Mapping for Caching
+WORKER_GPU_NLTK_DATA=./data/nltk_data
+WORKER_GPU_HF_CACHE=./data/huggingface_cache
+WORKER_GPU_OPENVOKE_REPO=./data/OpenVoice
+WORKER_GPU_OPENVOKE_CHECKPOINTS=./data/checkpoints_v2
+LIBREOFFICE_TMP_VOLUME=./data/libreoffice_tmp
 ```
 
 ## Key File Locations

--- a/README.md
+++ b/README.md
@@ -213,6 +213,27 @@ The TTS system uses a modular architecture for better maintainability and testin
 - **Slide Storage**: `/MWC/data/ppt/slides` (host) → MinIO presentations bucket
 - **Environment Variables**: `PPT_OUTPUT_VOLUME` and `PPT_SLIDES_VOLUME` in `.env`
 
+### Caching for Development (Configurable via .env)
+To improve performance during development and prevent re-downloading large AI models, you can mount several cache directories from the `worker_gpu` container to your local filesystem.
+
+- **NLTK Data**: Caches tokenizers and other data for text processing.
+- **Hugging Face Models**: Caches pre-trained models like BERT.
+- **OpenVoice Repo**: Caches the cloned OpenVoice repository.
+- **OpenVoice Checkpoints**: Caches the OpenVoice model weights.
+- **LibreOffice Temp Files**: Caches temporary files generated during presentation conversion.
+
+You can configure these mappings in your `.env` file:
+```
+# Worker GPU Caches
+WORKER_GPU_NLTK_DATA=./data/nltk_data
+WORKER_GPU_HF_CACHE=./data/huggingface_cache
+WORKER_GPU_OPENVOKE_REPO=./data/OpenVoice
+WORKER_GPU_OPENVOKE_CHECKPOINTS=./data/checkpoints_v2
+
+# LibreOffice Temporary Files
+LIBREOFFICE_TMP_VOLUME=./data/libreoffice_tmp
+```
+
 ### Storage Buckets
 - `ingest`: Uploaded PPTX files
 - `voice-clones`: Voice reference audio files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,10 @@ services:
       - minio
     volumes:
       - ./app:/app
+      - ${WORKER_GPU_NLTK_DATA:-./data/nltk_data}:/root/nltk_data
+      - ${WORKER_GPU_HF_CACHE:-./data/huggingface_cache}:/root/.cache/huggingface/hub
+      - ${WORKER_GPU_OPENVOKE_REPO:-./data/OpenVoice}:/OpenVoice
+      - ${WORKER_GPU_OPENVOKE_CHECKPOINTS:-./data/checkpoints_v2}:/checkpoints_v2
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-user}:${POSTGRES_PASSWORD:-password}@postgres:5432/${POSTGRES_DB:-presentation_gen_db}
       - CELERY_BROKER_URL=redis://redis:6379/0
@@ -136,6 +140,8 @@ services:
     container_name: ppt-libreoffice
     ports:
       - "18100:8100"
+    volumes:
+      - ${LIBREOFFICE_TMP_VOLUME:-./data/libreoffice_tmp}:/tmp
     environment:
       - MINIO_URL=minio:9000
       - MINIO_ACCESS_KEY=${MINIO_ROOT_USER:-minioadmin}


### PR DESCRIPTION
- Added volume mounts for worker_gpu and libreoffice services
- Caches for NLTK data, Hugging Face models, OpenVoice, and LibreOffice temp files can now be mounted from the host
- This improves development workflow by persisting caches and models across container rebuilds
- Updated docker-compose.yml to use environment variables for volume paths
- Added new environment variables to .env.example and .env.sample
- Updated README.md and Agents.md with documentation for the new feature